### PR TITLE
Update micro-ROS-Agent Dockerfile

### DIFF
--- a/micro-ROS-Agent/Dockerfile
+++ b/micro-ROS-Agent/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /uros_ws
 RUN . /opt/ros/$ROS_DISTRO/setup.sh \
 &&  . install/local_setup.sh \
 &&  ros2 run micro_ros_setup create_agent_ws.sh \
-&&  colcon build --meta src \
+&&  ros2 run micro_ros_setup build_agent.sh \
 &&  rm -rf log/ build/ src/
 
 # setup entrypoint


### PR DESCRIPTION
This PR modifies the Dockerfile used to build the micro-ROS-Agent, so it uses the provided build script by micro_ros_setup build tools.