### PR TITLE
support ROS_LOCALHOST_ONLY variable

### DIFF
--- a/micro-ROS-Agent/Dockerfile
+++ b/micro-ROS-Agent/Dockerfile
@@ -9,8 +9,7 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh \
 &&  rm -rf log/ build/ src/
 
 # Disable shared memory
-COPY disable_fastdds_shm.xml /tmp/
-ENV FASTRTPS_DEFAULT_PROFILES_FILE=/tmp/disable_fastdds_shm.xml
+COPY disable_fastdds_shm.xml disable_fastdds_shm_localhost_only.xml /tmp/
 
 # setup entrypoint
 COPY ./micro-ros_entrypoint.sh /

--- a/micro-ROS-Agent/disable_fastdds_shm_localhost_only.xml
+++ b/micro-ROS-Agent/disable_fastdds_shm_localhost_only.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--The only purpose of this file is to disable Fast-DDS SHM transport used by default to use UDPv4-->
+    <profiles xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles" >
+        <transport_descriptors>
+            <transport_descriptor>
+                <transport_id>CustomUdpTransport</transport_id>
+                <type>UDPv4</type>
+                <interfaceWhiteList>
+                    <address>127.0.0.1</address>
+                </interfaceWhiteList>
+            </transport_descriptor>
+        </transport_descriptors>
+
+        <participant profile_name="participant_profile" is_default_profile="true">
+            <rtps>
+                <userTransports>
+                    <transport_id>CustomUdpTransport</transport_id>
+                </userTransports>
+
+                <useBuiltinTransports>false</useBuiltinTransports>
+            </rtps>
+        </participant>
+    </profiles>

--- a/micro-ROS-Agent/micro-ros_entrypoint.sh
+++ b/micro-ROS-Agent/micro-ros_entrypoint.sh
@@ -1,3 +1,10 @@
 . "/opt/ros/$ROS_DISTRO/setup.sh"
 . "/uros_ws/install/local_setup.sh"
+
+if [ "$ROS_LOCALHOST_ONLY" = "1" ] ; then
+    export FASTRTPS_DEFAULT_PROFILES_FILE=/tmp/disable_fastdds_shm_localhost_only.xml
+else
+    export FASTRTPS_DEFAULT_PROFILES_FILE=/tmp/disable_fastdds_shm.xml
+fi
+
 exec ros2 run micro_ros_agent micro_ros_agent "$@"


### PR DESCRIPTION
Because micro-ros-agent doesn't respect ROS_LOCALHOST_ONLY, i added this workaround to support ROS_LOCALHOST_ONLY in container