### PR TITLE
run microros agent without sourcing colcon workspaces

### DIFF
--- a/micro-ROS-Agent/Dockerfile
+++ b/micro-ROS-Agent/Dockerfile
@@ -12,6 +12,6 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh \
 COPY disable_fastdds_shm.xml disable_fastdds_shm_localhost_only.xml /tmp/
 
 # setup entrypoint
-COPY ./micro-ros_entrypoint.sh /
-ENTRYPOINT ["/bin/sh", "/micro-ros_entrypoint.sh"]
+COPY ./micro-ros_entrypoint.sh ./micro-ros_agent_static_source.sh /
+ENTRYPOINT ["/micro-ros_entrypoint.sh"]
 CMD ["--help"]

--- a/micro-ROS-Agent/micro-ros_agent_static_source.sh
+++ b/micro-ROS-Agent/micro-ros_agent_static_source.sh
@@ -1,0 +1,1 @@
+export LD_LIBRARY_PATH=/uros_ws/install/micro_ros_agent/lib:/uros_ws/install/micro_ros_msgs/lib:/opt/ros/$ROS_DISTRO/opt/yaml_cpp_vendor/lib:/opt/ros/$ROS_DISTRO/lib/x86_64-linux-gnu:/opt/ros/$ROS_DISTRO/lib:$LD_LIBRARY_PATH

--- a/micro-ROS-Agent/micro-ros_entrypoint.sh
+++ b/micro-ROS-Agent/micro-ros_entrypoint.sh
@@ -9,7 +9,7 @@ fi
 if [ "$MICROROS_STATIC_SOURCE" = "1" ] ; then
     . /micro-ros_agent_static_source.sh
 
-    /uros_ws/install/micro_ros_agent/lib/micro_ros_agent/micro_ros_agent "$@"
+    exec /uros_ws/install/micro_ros_agent/lib/micro_ros_agent/micro_ros_agent "$@"
 else
     . "/opt/ros/$ROS_DISTRO/setup.sh"
     . "/uros_ws/install/local_setup.sh"

--- a/micro-ROS-Agent/micro-ros_entrypoint.sh
+++ b/micro-ROS-Agent/micro-ros_entrypoint.sh
@@ -1,5 +1,4 @@
-. "/opt/ros/$ROS_DISTRO/setup.sh"
-. "/uros_ws/install/local_setup.sh"
+#!/bin/bash
 
 if [ "$ROS_LOCALHOST_ONLY" = "1" ] ; then
     export FASTRTPS_DEFAULT_PROFILES_FILE=/tmp/disable_fastdds_shm_localhost_only.xml
@@ -7,4 +6,14 @@ else
     export FASTRTPS_DEFAULT_PROFILES_FILE=/tmp/disable_fastdds_shm.xml
 fi
 
-exec ros2 run micro_ros_agent micro_ros_agent "$@"
+if [ "$MICROROS_STATIC_SOURCE" = "1" ] ; then
+    export LD_LIBRARY_PATH=/uros_ws/install/micro_ros_agent/lib:/uros_ws/install/micro_ros_msgs/lib:/opt/ros/galactic/opt/yaml_cpp_vendor/lib:/opt/ros/galactic/lib/x86_64-linux-gnu:/opt/ros/galactic/lib:$LD_LIBRARY_PATH
+    PYTHONPATH=/uros_ws/install/micro_ros_msgs/lib/python3.8/site-packages:/opt/ros/galactic/lib/python3.8/site-packages:$PYTHONPATH
+    export ROS_DISTRO=galactic
+
+    /uros_ws/install/micro_ros_agent/lib/micro_ros_agent/micro_ros_agent "$@"
+else
+    . "/opt/ros/$ROS_DISTRO/setup.sh"
+    . "/uros_ws/install/local_setup.sh"
+    exec ros2 run micro_ros_agent micro_ros_agent "$@"
+fi

--- a/micro-ROS-Agent/micro-ros_entrypoint.sh
+++ b/micro-ROS-Agent/micro-ros_entrypoint.sh
@@ -7,9 +7,7 @@ else
 fi
 
 if [ "$MICROROS_STATIC_SOURCE" = "1" ] ; then
-    export LD_LIBRARY_PATH=/uros_ws/install/micro_ros_agent/lib:/uros_ws/install/micro_ros_msgs/lib:/opt/ros/galactic/opt/yaml_cpp_vendor/lib:/opt/ros/galactic/lib/x86_64-linux-gnu:/opt/ros/galactic/lib:$LD_LIBRARY_PATH
-    PYTHONPATH=/uros_ws/install/micro_ros_msgs/lib/python3.8/site-packages:/opt/ros/galactic/lib/python3.8/site-packages:$PYTHONPATH
-    export ROS_DISTRO=galactic
+    . /micro-ros_agent_static_source.sh
 
     /uros_ws/install/micro_ros_agent/lib/micro_ros_agent/micro_ros_agent "$@"
 else


### PR DESCRIPTION
Running python or sourcing colcon project is really slow on arm based devices.
This PR adds MICROROS_STATIC_SOURCE environment variable to the entry point of microros agent.
stting MICROROS_STATIC_SOURCE=1 will export statically the appropriate environment variables for microros agent to operate.