### PR TITLE
make the agent image 4x smaller thanks to multi stage build

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,7 +1,7 @@
 FROM ros:humble
 
-RUN mkdir -p uros_ws
-WORKDIR uros_ws
+WORKDIR /uros_ws
+
 RUN git clone --depth 1 -b humble https://github.com/micro-ROS/micro_ros_setup.git src/micro_ros_setup \
 &&  . /opt/ros/$ROS_DISTRO/setup.sh \
 &&  apt update \

--- a/micro-ROS-Agent/Dockerfile
+++ b/micro-ROS-Agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM microros/base:humble
+FROM microros/base:humble AS micro-ros-agent-builder
 
 WORKDIR /uros_ws
 RUN . /opt/ros/$ROS_DISTRO/setup.sh \
@@ -8,8 +8,20 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh \
 &&  ros2 run micro_ros_setup build_agent.sh \
 &&  rm -rf log/ build/ src/
 
+FROM ros:humble-ros-core
+
+COPY --from=micro-ros-agent-builder /uros_ws /uros_ws
+
+WORKDIR /uros_ws
+
 # Disable shared memory
 COPY disable_fastdds_shm.xml disable_fastdds_shm_localhost_only.xml /tmp/
+
+ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+ENV MICROROS_DISABLE_SHM=1
+
+RUN echo ". /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
+RUN echo ". /uros_ws/install/setup.bash" >> ~/.bashrc
 
 # setup entrypoint
 COPY ./micro-ros_entrypoint.sh /

--- a/micro-ROS-Agent/micro-ros_entrypoint.sh
+++ b/micro-ROS-Agent/micro-ros_entrypoint.sh
@@ -1,10 +1,12 @@
 . "/opt/ros/$ROS_DISTRO/setup.sh"
 . "/uros_ws/install/local_setup.sh"
 
-if [ "$ROS_LOCALHOST_ONLY" = "1" ] ; then
-    export FASTRTPS_DEFAULT_PROFILES_FILE=/tmp/disable_fastdds_shm_localhost_only.xml
-else
-    export FASTRTPS_DEFAULT_PROFILES_FILE=/tmp/disable_fastdds_shm.xml
+if [ "$MICROROS_DISABLE_SHM" = "1" ] ; then
+    if [ "$ROS_LOCALHOST_ONLY" = "1" ] ; then
+        export FASTRTPS_DEFAULT_PROFILES_FILE=/tmp/disable_fastdds_shm_localhost_only.xml
+    else
+        export FASTRTPS_DEFAULT_PROFILES_FILE=/tmp/disable_fastdds_shm.xml
+    fi
 fi
 
 exec ros2 run micro_ros_agent micro_ros_agent "$@"


### PR DESCRIPTION
- `microros/micro-ros-agent:humble` Docker image will be 4 times smaller (1.6GB vs 0.4GB)
- added `MICROROS_DISABLE_SHM` env (with default set to `1` for backward compatibility) allowing you to use your own DDS profile file 

You can test changes with `donowak/micro-ros-agent:humble` docker image (generated from https://github.com/DominikN/micro-ros-agent-minimal)