### PR TITLE
fixed ros2 not found

### DIFF
--- a/micro-ROS-demos/Dockerfile
+++ b/micro-ROS-demos/Dockerfile
@@ -1,5 +1,7 @@
 FROM microros/base:humble
 
+SHELL ["/bin/bash", "-c"]
+
 WORKDIR /uros_ws
 
 RUN apt update \
@@ -13,4 +15,4 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh \
 
 # setup entrypoint
 COPY ./micro-ros_entrypoint.sh /
-ENTRYPOINT ["/bin/sh", "/micro-ros_entrypoint.sh"]
+ENTRYPOINT "/micro-ros_entrypoint.sh"


### PR DESCRIPTION
Basically, need to declare the shell that ros2 is registered to use.