### PR TITLE
Add crossbuild-essential-armel toolchain for ARMv5TE Linux targets

### DIFF
--- a/micro-ROS-static-library-builder/Dockerfile
+++ b/micro-ROS-static-library-builder/Dockerfile
@@ -38,6 +38,10 @@ RUN git clone -b jazzy https://github.com/micro-ROS/micro-ros-build.git src/micr
     &&  rm -rf log/ build/ src/* \
     &&  rm -rf /var/lib/apt/lists/*
 
+RUN apt update \
+    && apt install -y --no-install-recommends crossbuild-essential-armel \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY ./entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]


### PR DESCRIPTION
Adds a separate RUN layer to install the arm-linux-gnueabi cross-compiler, needed to build micro-ROS static libraries for Linux-based ARM targets such as the LEGO Mindstorms EV3 (ev3dev, ARMv5TE).